### PR TITLE
bind agent in all interfaces by default

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -23,7 +23,7 @@ take consensus decisions`,
 		agentFlagCheck()
 		http.HandleFunc("/agent/", handlerAgent)
 		log.Println("Starting agent on port 10001")
-		http.ListenAndServe("localhost:10001", nil)
+		http.ListenAndServe("0.0.0.0:10001", nil)
 	},
 }
 

--- a/contrib/cluster-maxscale/docker-compose.yml
+++ b/contrib/cluster-maxscale/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - "3306"
 
   replication-manager:
+    image: replication-manager
     build: ../..
     command: monitor --interactive=false --hosts=mariadb1,mariadb2,mariadb3 --user=root --rpluser=repl:pass --verbose
     depends_on:
@@ -28,6 +29,7 @@ services:
     volumes:
       - ./mariadb.sql:/docker-entrypoint-initdb.d/mariadb.sql:ro
   agent1:
+    image: replication-manager
     build: ../..
     command: agent --interactive=false --hosts=mariadb1 --user=root --rpluser=repl:pass
     depends_on:
@@ -37,6 +39,7 @@ services:
     extends: mariadb1
     command: --log-bin --skip-name-resolve --server_id=2
   agent2:
+    image: replication-manager
     build: ../..
     command: agent --interactive=false --hosts=mariadb2 --user=root --rpluser=repl:pass
     depends_on:
@@ -46,6 +49,7 @@ services:
     extends: mariadb1
     command: --log-bin --skip-name-resolve --server_id=3
   agent3:
+    image: replication-manager
     build: ../..
     command: agent --interactive=false --hosts=mariadb3 --user=root --rpluser=repl:pass
     depends_on:


### PR DESCRIPTION
The monitor instance in the docker-compose file cannot check the agents because they're only listening on localhost, this allows them to be reached from the outside.